### PR TITLE
fix: Use 'Var' instead of 'Params' suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,25 +50,25 @@ import (
 	"github.com/sourcegraph/querygen/lib/interpolate"
 )
 
-type partyAttendeesQueryParams struct {
+type partyAttendeesQueryVars struct {
 	partyId int
 }
 
-var _ interpolate.QueryParams = &partyAttendeesQueryParams{}
+var _ interpolate.QueryVars = &partyAttendeesQueryVars{}
 
 // methods omitted...
 
-type bestChoiceCakeQueryParams struct {
+type bestChoiceCakeQueryVars struct {
 	partyId          int
 	excludedCakeType string
 }
 
-var _ interpolate.QueryParams = &bestChoiceCakeQueryParams{}
+var _ interpolate.QueryVars = &bestChoiceCakeQueryVars{}
 
 // methods omitted...
 ```
 
-You can use these structs with `interpolate.Do(myQuery, &myQueryParams{...})` function
+You can use these structs with `interpolate.Do(myQuery, &myQueryVars{...})` function
 to generate a [`*sqlf.Query`](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/keegancsmith/sqlf%24%40master+file:sqlf.go+type:symbol+Query&patternType=keyword&sm=0)
 which can then be executed. The `interpolate.Do` function replaces the `sqlf.Sprintf`
 function.

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -48,7 +48,7 @@ will satisfy the `QueryParam` interface in the matching library version.
   optionally followed by  `_` or numbers.
 - The constant must have one or more instances of interpolation syntax.
 
-The generated type name will be `queryVarName + "Params"`.
+The generated type name will be `queryVarName + "Vars"`.
 
 ### File naming
 

--- a/internal/model.go
+++ b/internal/model.go
@@ -77,7 +77,7 @@ func (b *goStructBuilder) tryBuild() *GoStruct {
 	for it := b.fieldMap.Oldest(); it != nil; it = it.Next() {
 		fields = append(fields, *it.Value)
 	}
-	return &GoStruct{b.queryConst.Name + "Params", fields}
+	return &GoStruct{b.queryConst.Name + "Vars", fields}
 }
 
 func (b *goStructBuilder) AddInterpolationMatch(index int, matches []string) error {
@@ -184,7 +184,7 @@ func WriteStructs(wanted []GoStruct, buf *bytes.Buffer, shouldImportInterpolate 
 		}
 		buf.WriteString("}\n\n")
 
-		buf.WriteString(fmt.Sprintf("var _ %sQueryParams = &%s{}\n\n", packagePrefix, goStruct.TypeName))
+		buf.WriteString(fmt.Sprintf("var _ %sQueryVars = &%s{}\n\n", packagePrefix, goStruct.TypeName))
 
 		type perIndexData = struct {
 			fieldName  string

--- a/lib/interpolate/interpolate.go
+++ b/lib/interpolate/interpolate.go
@@ -1,12 +1,13 @@
 package interpolate
 
 import (
-	"github.com/keegancsmith/sqlf"
+	"fmt"
 
+	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/querygen/internal"
 )
 
-type QueryParams interface {
+type QueryVars interface {
 	// FormatSpecifiers returns 1 element per interpolation
 	FormatSpecifiers() []string
 	// FormatArgs returns 1 element per interpolation
@@ -21,7 +22,10 @@ func (e *QueryDoesntUseInterpolationError) Error() string {
 	return "query doesn't use interpolation"
 }
 
-func Do(query string, q QueryParams) (*sqlf.Query, error) {
+// Do creates a sqlf.Query from the given query string and QueryVars.
+//
+// If the query doesn't use interpolation, returns nil, &QueryDoesntUseInterpolationError{}.
+func Do(query string, q QueryVars) (*sqlf.Query, error) {
 	formatSpecs := q.FormatSpecifiers()
 	matchIndex := 0
 	modifiedQuery := internal.SubstitutionRegex.ReplaceAllStringFunc(query, func(match string) string {
@@ -31,6 +35,24 @@ func Do(query string, q QueryParams) (*sqlf.Query, error) {
 	})
 	if matchIndex == 0 {
 		return nil, &QueryDoesntUseInterpolationError{}
+	}
+	return sqlf.Sprintf(modifiedQuery, q.FormatArgs()...), nil
+}
+
+// MustDo creates a sqlf.Query from the given query string and QueryVars.
+//
+// Panics if the query doesn't use interpolation.
+func MustDo(query string, q QueryVars) (*sqlf.Query, error) {
+	formatSpecs := q.FormatSpecifiers()
+	matchIndex := 0
+	modifiedQuery := internal.SubstitutionRegex.ReplaceAllStringFunc(query, func(match string) string {
+		replacement := formatSpecs[matchIndex]
+		matchIndex += 1
+		return replacement
+	})
+	if matchIndex == 0 {
+		err := &QueryDoesntUseInterpolationError{}
+		panic(fmt.Sprintf("%s: %25s", err.Error(), query))
 	}
 	return sqlf.Sprintf(modifiedQuery, q.FormatArgs()...), nil
 }

--- a/lib/interpolate/interpolate_query_gen_test.go
+++ b/lib/interpolate/interpolate_query_gen_test.go
@@ -2,46 +2,46 @@
 // You may only edit import statements.
 package interpolate
 
-type myArgsQueryParams struct {
+type myArgsQueryVars struct {
 	TableName string
 	WantId    int
 }
 
-var _ QueryParams = &myArgsQueryParams{}
+var _ QueryVars = &myArgsQueryVars{}
 
-func (qp *myArgsQueryParams) FormatSpecifiers() []string {
+func (qp *myArgsQueryVars) FormatSpecifiers() []string {
 	return []string{"%s", "%d"}
 }
 
-func (qp *myArgsQueryParams) FormatArgs() []any {
+func (qp *myArgsQueryVars) FormatArgs() []any {
 	return []any{qp.TableName, qp.WantId}
 }
 
-type partyAttendeesQueryParams struct {
+type partyAttendeesQueryVars struct {
 	partyId int
 }
 
-var _ QueryParams = &partyAttendeesQueryParams{}
+var _ QueryVars = &partyAttendeesQueryVars{}
 
-func (qp *partyAttendeesQueryParams) FormatSpecifiers() []string {
+func (qp *partyAttendeesQueryVars) FormatSpecifiers() []string {
 	return []string{"%d"}
 }
 
-func (qp *partyAttendeesQueryParams) FormatArgs() []any {
+func (qp *partyAttendeesQueryVars) FormatArgs() []any {
 	return []any{qp.partyId}
 }
 
-type bestChoiceCakeQueryParams struct {
+type bestChoiceCakeQueryVars struct {
 	partyId          int
 	excludedCakeType string
 }
 
-var _ QueryParams = &bestChoiceCakeQueryParams{}
+var _ QueryVars = &bestChoiceCakeQueryVars{}
 
-func (qp *bestChoiceCakeQueryParams) FormatSpecifiers() []string {
+func (qp *bestChoiceCakeQueryVars) FormatSpecifiers() []string {
 	return []string{"%d", "%s"}
 }
 
-func (qp *bestChoiceCakeQueryParams) FormatArgs() []any {
+func (qp *bestChoiceCakeQueryVars) FormatArgs() []any {
 	return []any{qp.partyId, qp.excludedCakeType}
 }

--- a/lib/interpolate/interpolate_test.go
+++ b/lib/interpolate/interpolate_test.go
@@ -32,7 +32,7 @@ var _ = bestChoiceCakeQuery
 func TestDo(t *testing.T) {
 	type TestCase struct {
 		query      string
-		input      QueryParams
+		input      QueryVars
 		expect     autogold.Value
 		expectArgs autogold.Value
 	}
@@ -40,7 +40,7 @@ func TestDo(t *testing.T) {
 	testCases := []TestCase{
 		{
 			query:      myArgsQuery,
-			input:      &myArgsQueryParams{TableName: "T", WantId: 1},
+			input:      &myArgsQueryVars{TableName: "T", WantId: 1},
 			expect:     autogold.Expect("SELECT * from $1 WHERE id = $2"),
 			expectArgs: autogold.Expect([]interface{}{"T", 1}),
 		},

--- a/tests/simple/simple_query_gen.go
+++ b/tests/simple/simple_query_gen.go
@@ -6,16 +6,16 @@ import (
 	"github.com/sourcegraph/querygen/lib/interpolate"
 )
 
-type selectAllQueryParams struct {
+type selectAllQueryVars struct {
 	tableName string
 }
 
-var _ interpolate.QueryParams = &selectAllQueryParams{}
+var _ interpolate.QueryVars = &selectAllQueryVars{}
 
-func (qp *selectAllQueryParams) FormatSpecifiers() []string {
+func (qp *selectAllQueryVars) FormatSpecifiers() []string {
 	return []string{"%s"}
 }
 
-func (qp *selectAllQueryParams) FormatArgs() []any {
+func (qp *selectAllQueryVars) FormatArgs() []any {
 	return []any{qp.tableName}
 }

--- a/tests/simple/with_imports_query_gen.go
+++ b/tests/simple/with_imports_query_gen.go
@@ -7,16 +7,16 @@ import (
 	_ "math" // Added by hand
 )
 
-type myQueryParams struct {
+type myQueryVars struct {
 	abc string
 }
 
-var _ interpolate.QueryParams = &myQueryParams{}
+var _ interpolate.QueryVars = &myQueryVars{}
 
-func (qp *myQueryParams) FormatSpecifiers() []string {
+func (qp *myQueryVars) FormatSpecifiers() []string {
 	return []string{"%s"}
 }
 
-func (qp *myQueryParams) FormatArgs() []any {
+func (qp *myQueryVars) FormatArgs() []any {
 	return []any{qp.abc}
 }


### PR DESCRIPTION
In a parameterized statement, 'parameters' refers to
the placeholders in the statement, whereas 'variables'
refer to the values passed alongside the statement.
