### PR TITLE
chore: Remove FormatSpecifier machinery

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -2,27 +2,14 @@
 
 ## Interpolation syntax
 
-The most general interpolation syntax is:
-
-```
-{{ident : type : formatSpecifier}}
-```
-
-- `ident` will be the name of the field in the associated generated struct.
-- `type` will be the type of the field
-- `formatSpecifier` specifies how the value will be formatted.
-  So the usual Go syntax with `%d` etc.
-
-`formatSpecifier` can be omitted if `type` is one of:
-- An integral type (`int`, `int32`, `uint8` etc.)
-- `string`
-- A type which has one of the above types as the underlying type.
-
-The simpler syntax is:
+The typical interpolation syntax is:
 
 ```
 {{ident : type}}
 ```
+
+- `ident` will be the name of the field in the associated generated struct.
+- `type` will be the type of the field
 
 If using the same parameter multiple times, you may use `_`
 from the second occurrence onwards, instead of repeating the type name.

--- a/internal/parse.go
+++ b/internal/parse.go
@@ -11,7 +11,6 @@ import (
 //
 //	{{ fieldName : typeName }}
 //	{{ fieldName : _ }} // allowed for 2nd, 3rd etc. interpolation of same field
-//	{{ fieldName : typeName : formatSpec }} where formatSpec may be %v or similar
 //
 // formatSpec must not contain positional arguments (i.e. %[0]f is not OK)
 var SubstitutionRegex *regexp.Regexp = func() *regexp.Regexp {
@@ -25,21 +24,19 @@ var SubstitutionRegex *regexp.Regexp = func() *regexp.Regexp {
 // GoStructFieldBuilder maps N-1 to GoStructField, as the same field
 // may be interpolated multiple times in the same query.
 type GoStructFieldBuilder struct {
-	Name                    string
-	TypeName                string
-	ExplicitFormatSpecifier string
-	Index                   int
+	Name     string
+	TypeName string
+	Index    int
 }
 
 func NewFieldBuilder(matchIndex int, matches []string) GoStructFieldBuilder {
-	if len(matches) < 6 {
-		panic("expected field name at index 1, type name at index 2, and optional format specifier at index 5")
+	if len(matches) < 3 {
+		panic("expected field name at index 1, type name at index 2")
 	}
 	return GoStructFieldBuilder{
-		Name:                    matches[1],
-		TypeName:                matches[2],
-		ExplicitFormatSpecifier: matches[5],
-		Index:                   matchIndex,
+		Name:     matches[1],
+		TypeName: matches[2],
+		Index:    matchIndex,
 	}
 }
 

--- a/internal/parse_test.go
+++ b/internal/parse_test.go
@@ -38,17 +38,15 @@ func TestSubstitutionRegex(t *testing.T) {
 			},
 		})},
 		{
-			input: `SELECT * from T WHERE X = {{x: *int: %s}} AND Y = {{uploadedParts: any: %s}}`, builders: autogold.Expect([]GoStructFieldBuilder{
+			input: `SELECT * from T WHERE X = {{x: *int: %s}} AND Y = {{uploadedParts: any}}`, builders: autogold.Expect([]GoStructFieldBuilder{
 				{
-					Name:                    "x",
-					TypeName:                "*int",
-					ExplicitFormatSpecifier: "%s",
+					Name:     "x",
+					TypeName: "*int",
 				},
 				{
-					Name:                    "uploadedParts",
-					TypeName:                "any",
-					ExplicitFormatSpecifier: "%s",
-					Index:                   1,
+					Name:     "uploadedParts",
+					TypeName: "any",
+					Index:    1,
 				},
 			}),
 		},

--- a/lib/interpolate/interpolate.go
+++ b/lib/interpolate/interpolate.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/querygen/internal"
 )
 
 type QueryVars interface {
-	// FormatSpecifiers returns 1 element per interpolation
-	FormatSpecifiers() []string
 	// FormatArgs returns 1 element per interpolation
 	FormatArgs() []any
 }
@@ -26,14 +25,11 @@ func (e *QueryDoesntUseInterpolationError) Error() string {
 //
 // If the query doesn't use interpolation, returns nil, &QueryDoesntUseInterpolationError{}.
 func Do(query string, q QueryVars) (*sqlf.Query, error) {
-	formatSpecs := q.FormatSpecifiers()
-	matchIndex := 0
-	modifiedQuery := internal.SubstitutionRegex.ReplaceAllStringFunc(query, func(match string) string {
-		replacement := formatSpecs[matchIndex]
-		matchIndex += 1
-		return replacement
-	})
-	if matchIndex == 0 {
+	modifiedQuery := internal.SubstitutionRegex.ReplaceAllString(query, "%s")
+	// Just doing a length check instead of a content check is OK
+	// because a query with one or more interpolations must be longer
+	// than the query with replacements.
+	if len(modifiedQuery) == len(query) {
 		return nil, &QueryDoesntUseInterpolationError{}
 	}
 	return sqlf.Sprintf(modifiedQuery, q.FormatArgs()...), nil
@@ -42,17 +38,10 @@ func Do(query string, q QueryVars) (*sqlf.Query, error) {
 // MustDo creates a sqlf.Query from the given query string and QueryVars.
 //
 // Panics if the query doesn't use interpolation.
-func MustDo(query string, q QueryVars) (*sqlf.Query, error) {
-	formatSpecs := q.FormatSpecifiers()
-	matchIndex := 0
-	modifiedQuery := internal.SubstitutionRegex.ReplaceAllStringFunc(query, func(match string) string {
-		replacement := formatSpecs[matchIndex]
-		matchIndex += 1
-		return replacement
-	})
-	if matchIndex == 0 {
-		err := &QueryDoesntUseInterpolationError{}
+func MustDo(query string, q QueryVars) *sqlf.Query {
+	result, err := Do(query, q)
+	if err != nil {
 		panic(fmt.Sprintf("%s: %25s", err.Error(), query))
 	}
-	return sqlf.Sprintf(modifiedQuery, q.FormatArgs()...), nil
+	return result
 }

--- a/lib/interpolate/interpolate_query_gen_test.go
+++ b/lib/interpolate/interpolate_query_gen_test.go
@@ -9,10 +9,6 @@ type myArgsQueryVars struct {
 
 var _ QueryVars = &myArgsQueryVars{}
 
-func (qp *myArgsQueryVars) FormatSpecifiers() []string {
-	return []string{"%s", "%d"}
-}
-
 func (qp *myArgsQueryVars) FormatArgs() []any {
 	return []any{qp.TableName, qp.WantId}
 }
@@ -22,10 +18,6 @@ type partyAttendeesQueryVars struct {
 }
 
 var _ QueryVars = &partyAttendeesQueryVars{}
-
-func (qp *partyAttendeesQueryVars) FormatSpecifiers() []string {
-	return []string{"%d"}
-}
 
 func (qp *partyAttendeesQueryVars) FormatArgs() []any {
 	return []any{qp.partyId}
@@ -37,10 +29,6 @@ type bestChoiceCakeQueryVars struct {
 }
 
 var _ QueryVars = &bestChoiceCakeQueryVars{}
-
-func (qp *bestChoiceCakeQueryVars) FormatSpecifiers() []string {
-	return []string{"%d", "%s"}
-}
 
 func (qp *bestChoiceCakeQueryVars) FormatArgs() []any {
 	return []any{qp.partyId, qp.excludedCakeType}

--- a/tests/simple/simple_query_gen.go
+++ b/tests/simple/simple_query_gen.go
@@ -12,10 +12,6 @@ type selectAllQueryVars struct {
 
 var _ interpolate.QueryVars = &selectAllQueryVars{}
 
-func (qp *selectAllQueryVars) FormatSpecifiers() []string {
-	return []string{"%s"}
-}
-
 func (qp *selectAllQueryVars) FormatArgs() []any {
 	return []any{qp.tableName}
 }

--- a/tests/simple/with_imports_query_gen.go
+++ b/tests/simple/with_imports_query_gen.go
@@ -13,10 +13,6 @@ type myQueryVars struct {
 
 var _ interpolate.QueryVars = &myQueryVars{}
 
-func (qp *myQueryVars) FormatSpecifiers() []string {
-	return []string{"%s"}
-}
-
 func (qp *myQueryVars) FormatArgs() []any {
 	return []any{qp.abc}
 }


### PR DESCRIPTION
Previously, I thought that was used for basic run-time
type-checking, but the format specifiers are basically
just ignored by sqlf when creating a parameterized stmt
